### PR TITLE
Reverse pressed and released naming.

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -14,9 +14,9 @@ Button2::Button2(byte attachTo, byte buttonMode /* = INPUT_PULLUP */, boolean ac
   pin = attachTo;
   setDebounceTime(debounceTimeout);
   pinMode(attachTo, buttonMode);
-  pressed = activeLow ? HIGH : LOW;
-  released = activeLow ? LOW : HIGH;
-  state = pressed;
+  released = activeLow ? HIGH : LOW;
+  pressed = activeLow ? LOW : HIGH;
+  state = released;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -88,7 +88,7 @@ unsigned int Button2::wasPressedFor() {
 /////////////////////////////////////////////////////////////////
 
 boolean Button2::isPressed() {
-  return (state == released);
+  return (state == pressed);
 }
     
 /////////////////////////////////////////////////////////////////
@@ -110,14 +110,14 @@ void Button2::loop() {
   state = digitalRead(pin);
 
   // is button pressed?
-  if (prev_state == pressed && state == released) {
+  if (prev_state == released && state == pressed) {
     down_ms = millis();
     pressed_triggered = false;
     click_count++;
     click_ms = down_ms;
 
   // is the button released?
-  } else if (prev_state == released && state == pressed) {
+  } else if (prev_state == pressed && state == released) {
     down_time_ms = millis() - down_ms;
     // is it beyond debounce time?
     if (down_time_ms >= debounce_time_ms) {
@@ -133,13 +133,13 @@ void Button2::loop() {
     }
 
   // trigger pressed event (after debounce has passed)
-  } else if (state == released && !pressed_triggered && (millis() - down_ms >= debounce_time_ms)) {
+  } else if (state == pressed && !pressed_triggered && (millis() - down_ms >= debounce_time_ms)) {
     if (change_cb != NULL) change_cb (*this);      
     if (pressed_cb != NULL) pressed_cb (*this);
     pressed_triggered = true;
   
-  // is the button pressed and the time has passed for multiple clicks?
-  } else if (state == pressed && millis() - click_ms > DOUBLECLICK_MS) {
+  // is the button released and the time has passed for multiple clicks?
+  } else if (state == released && millis() - click_ms > DOUBLECLICK_MS) {
     // was there a longclick?
     if (longclick_detected) {
       // was it part of a combination?

--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -14,9 +14,8 @@ Button2::Button2(byte attachTo, byte buttonMode /* = INPUT_PULLUP */, boolean ac
   pin = attachTo;
   setDebounceTime(debounceTimeout);
   pinMode(attachTo, buttonMode);
-  released = activeLow ? HIGH : LOW;
   pressed = activeLow ? LOW : HIGH;
-  state = released;
+  state = activeLow ? HIGH : LOW;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -90,16 +89,22 @@ unsigned int Button2::wasPressedFor() {
 boolean Button2::isPressed() {
   return (state == pressed);
 }
-    
+
 /////////////////////////////////////////////////////////////////
 
-unsigned int Button2::getNumberOfClicks() {
+boolean Button2::isPressedRaw() {
+  return (digitalRead(pin) == pressed);
+}
+
+/////////////////////////////////////////////////////////////////
+
+byte Button2::getNumberOfClicks() {
     return click_count;
 }
 
 /////////////////////////////////////////////////////////////////
 
-unsigned int Button2::getClickType() {
+byte Button2::getClickType() {
     return last_click_type;
 }
 
@@ -110,17 +115,17 @@ void Button2::loop() {
   state = digitalRead(pin);
 
   // is button pressed?
-  if (prev_state == released && state == pressed) {
+  if (prev_state != pressed && state == pressed) {
     down_ms = millis();
     pressed_triggered = false;
-    click_count++;
     click_ms = down_ms;
 
   // is the button released?
-  } else if (prev_state == pressed && state == released) {
+  } else if (prev_state == pressed && state != pressed) {
     down_time_ms = millis() - down_ms;
     // is it beyond debounce time?
     if (down_time_ms >= debounce_time_ms) {
+	  click_count++;
       // trigger release        
       if (change_cb != NULL) change_cb (*this);
       if (released_cb != NULL) released_cb (*this);
@@ -139,7 +144,7 @@ void Button2::loop() {
     pressed_triggered = true;
   
   // is the button released and the time has passed for multiple clicks?
-  } else if (state == released && millis() - click_ms > DOUBLECLICK_MS) {
+  } else if (state != pressed && millis() - click_ms > DOUBLECLICK_MS) {
     // was there a longclick?
     if (longclick_detected) {
       // was it part of a combination?

--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -125,7 +125,6 @@ void Button2::loop() {
     down_time_ms = millis() - down_ms;
     // is it beyond debounce time?
     if (down_time_ms >= debounce_time_ms) {
-	  click_count++;
       // trigger release        
       if (change_cb != NULL) change_cb (*this);
       if (released_cb != NULL) released_cb (*this);
@@ -139,9 +138,10 @@ void Button2::loop() {
 
   // trigger pressed event (after debounce has passed)
   } else if (state == pressed && !pressed_triggered && (millis() - down_ms >= debounce_time_ms)) {
+    pressed_triggered = true;
+    click_count++;
     if (change_cb != NULL) change_cb (*this);      
     if (pressed_cb != NULL) pressed_cb (*this);
-    pressed_triggered = true;
   
   // is the button released and the time has passed for multiple clicks?
   } else if (state != pressed && millis() - click_ms > DOUBLECLICK_MS) {

--- a/src/Button2.h
+++ b/src/Button2.h
@@ -35,12 +35,11 @@
 class Button2 {
   protected:
     byte pin;
-    int prev_state;
-    int state;
-    int pressed;
-    int released;
+    byte prev_state;
+    byte state;
+    byte pressed;
     byte click_count = 0;
-    unsigned int last_click_type = 0;
+    byte last_click_type = 0;
     unsigned long click_ms;
     unsigned long down_ms;
     unsigned int debounce_time_ms;
@@ -75,9 +74,10 @@ class Button2 {
 
     unsigned int wasPressedFor();
     boolean isPressed();
+    boolean isPressedRaw();
 
-    unsigned int getNumberOfClicks();
-    unsigned int getClickType();
+    byte getNumberOfClicks();
+    byte getClickType();
     
     bool operator==(Button2 &rhs);
 


### PR DESCRIPTION
Reversed pressed and released naming and states so the code aligns with the intent.

For instance, if a button is configured with activeLow then the state of the active button, i.e. when pressed, must be a LOW reading. The released and pressed variables seems to have been reversed, but the reversal was consistent in the remainder of the code making it work - albeit confusingly so. This correct the reversed variable usage and a single comment that was also reversed (other comments are correct). The functionality of the code is unchanged.