### PR TITLE
Moved activeLow outside of isCapacitive condition

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -13,13 +13,13 @@
 Button2::Button2(byte attachTo, byte buttonMode /* = INPUT_PULLUP */, boolean isCapacitive /* = false */, boolean activeLow /* = true */, unsigned int debounceTimeout /* = DEBOUNCE_MS */) {
   pin = attachTo;
   setDebounceTime(debounceTimeout);
+  pressed = activeLow ? LOW : HIGH;
+  state = activeLow ? HIGH : LOW;
   if (!isCapacitive) {
     pinMode(attachTo, buttonMode);
   } else {
     capacitive = true;
-    pressed = activeLow ? LOW : HIGH;
-    state = activeLow ? HIGH : LOW;
-  }
+  }	
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Was working on a board with active high inputs and realized the activeLow argument wasn't working, noticed that it was wrapped under the isCapacitive condition, moved it outside.