### PR TITLE
Account for activeLow agrument

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -32,7 +32,7 @@ void Button2::begin(int attachTo, byte buttonMode /* = INPUT_PULLUP */, boolean 
 /////////////////////////////////////////////////////////////////
 
 Button2::Button2(int attachTo, byte buttonMode /* = INPUT_PULLUP */, boolean isCapacitive /* = false */, boolean activeLow /* = true */, unsigned int debounceTimeout /* = DEBOUNCE_MS */) {
-  begin(attachTo, buttonMode, isCapacitive, debounceTimeout);
+  begin(attachTo, buttonMode, isCapacitive, activeLow, debounceTimeout);
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When creating a button instance argument activeLow was not accounted for.