### PR TITLE
Initialize longclick_detected_counter with 0

### DIFF
--- a/src/Button2.h
+++ b/src/Button2.h
@@ -48,7 +48,7 @@ protected:
   unsigned long down_ms;
 
   bool longclick_detected_retriggerable;
-  uint16_t longclick_detected_counter;
+  uint16_t longclick_detected_counter = 0;
   bool longclick_detected = false;
   bool longclick_detected_reported = false;
   


### PR DESCRIPTION
On some systems this is not implicitly initialized with 0, which causes the LongClickDetected handler not to be called the first time.