### PR TITLE
Trigger was_pressed flag for both single_press and long_press

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -410,8 +410,8 @@ void Button2::_reportClicks() {
       } else {
         last_click_type = single_click;
         if (click_cb != NULL) click_cb (*this);
-        was_pressed = true;
       }
+      was_pressed = true;
       break;
 
     case 2: 


### PR DESCRIPTION
Fix for issue #54 
When polling `button.wasPressed()`  click `long_pressed` is detected only once when button has released. `button.setLongClickDetectedRetriggerable(true);` doesn't change that behavior