### PR TITLE
Create ESP32S2S3CapacitiveTouch.ino

### DIFF
--- a/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
+++ b/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
@@ -1,0 +1,65 @@
+/////////////////////////////////////////////////////////////////
+
+#if !defined(ESP32)
+  #error This sketch needs an ESP32 S2 or S3
+#else
+
+/////////////////////////////////////////////////////////////////
+
+#include "Button2.h"
+
+#define TOUCH_PIN T5 // Must declare the touch assignment, not the pin.
+
+int threshold = 1500;   // ESP32S2 
+bool touchdetected = false; // true is for unpressed, pressed = false;
+byte buttonState = HIGH;
+/////////////////////////////////////////////////////////////////
+
+Button2 button;
+
+/////////////////////////////////////////////////////////////////
+void gotTouch() {
+  touchdetected = true;
+}
+
+
+byte capStateHandler() {
+    return buttonState;
+}
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+    Serial.begin(9600);
+    delay(50);
+    Serial.println("\n\nCapacitive Touch Demo");
+    touchAttachInterrupt(TOUCH_PIN, gotTouch, threshold); 
+    button.setDebounceTime(35);
+    button.setButtonStateFunction(capStateHandler);
+    button.setClickHandler(click);
+    button.begin(VIRTUAL_PIN);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void loop() {
+  button.loop();
+  if (touchdetected) {
+    touchdetected = false;
+    if (touchInterruptGetLastStatus(TOUCH_PIN)) {
+      buttonState = LOW;
+    } else {
+      buttonState = HIGH;
+    }
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+
+void click(Button2& btn) {
+    Serial.println("click\n");
+}
+
+/////////////////////////////////////////////////////////////////
+#endif
+/////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Uses the touch interrupt and last status available to the ESP32S2 and ESP32S3.

I was unable to get the library working with the included example for capacitive touch.  I built this example using the included capacitive touch examples included with the ESP32 library.  This one works only with ESP32 S2 and S3 chips as the function touchInterruptGetLastStatus is only available on those chips and not the classic ESP32.   I'm putting an example together for that one though and will put another pull request through when I'm done.  This worked very reliably to detect single, double, triple and long clicks in my testing (with an expanded sketch to include those functions).