### PR TITLE
Added New Capacitive Touch Examples

### DIFF
--- a/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
+++ b/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
@@ -1,0 +1,65 @@
+/////////////////////////////////////////////////////////////////
+
+#if !defined(ESP32)
+  #error This sketch needs an ESP32 S2 or S3
+#else
+
+/////////////////////////////////////////////////////////////////
+
+#include "Button2.h"
+
+#define TOUCH_PIN T5 // Must declare the touch assignment, not the pin.
+
+int threshold = 1500;   // ESP32S2 
+bool touchdetected = false; // true is for unpressed, pressed = false;
+byte buttonState = HIGH;
+/////////////////////////////////////////////////////////////////
+
+Button2 button;
+
+/////////////////////////////////////////////////////////////////
+void gotTouch() {
+  touchdetected = true;
+}
+
+
+byte capStateHandler() {
+    return buttonState;
+}
+
+/////////////////////////////////////////////////////////////////
+
+void setup() {
+    Serial.begin(9600);
+    delay(50);
+    Serial.println("\n\nCapacitive Touch Demo");
+    touchAttachInterrupt(TOUCH_PIN, gotTouch, threshold); 
+    button.setDebounceTime(35);
+    button.setButtonStateFunction(capStateHandler);
+    button.setClickHandler(click);
+    button.begin(VIRTUAL_PIN);
+}
+
+/////////////////////////////////////////////////////////////////
+
+void loop() {
+  button.loop();
+  if (touchdetected) {
+    touchdetected = false;
+    if (touchInterruptGetLastStatus(TOUCH_PIN)) {
+      buttonState = LOW;
+    } else {
+      buttonState = HIGH;
+    }
+  }
+}
+
+/////////////////////////////////////////////////////////////////
+
+void click(Button2& btn) {
+    Serial.println("click\n");
+}
+
+/////////////////////////////////////////////////////////////////
+#endif
+/////////////////////////////////////////////////////////////////

--- a/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
+++ b/examples/ESP32S2S3CapacitiveTouch/ESP32S2S3CapacitiveTouch.ino
@@ -11,8 +11,8 @@
 #define TOUCH_PIN T5 // Must declare the touch assignment, not the pin.
 
 int threshold = 1500;   // ESP32S2 
-bool touchdetected = false; // true is for unpressed, pressed = false;
-byte buttonState = HIGH;
+bool touchdetected = false; 
+byte buttonState = HIGH;// HIGH is for unpressed, pressed = LOW
 /////////////////////////////////////////////////////////////////
 
 Button2 button;


### PR DESCRIPTION
I was unable to get the library working with the included example for capacitive touch. I built these examples using the capacitive touch examples included with the ESP32 library. One works only with ESP32 S2 and S3 chips as the function touchInterruptGetLastStatus is only available on those chips and not the classic ESP32. The "classic" sketch works with all ESP32 chips but is quite a bit more complicated so I would only use when you have to.  These worked very reliably to detect single, double, triple and long clicks in my testing (with an expanded sketch to include those functions).