### PR TITLE
Add separate longclick retrigger delay

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -140,6 +140,16 @@ void Button2::setLongClickHandler(CallbackFunction f) {
 
 void Button2::setLongClickDetectedRetriggerable(bool retriggerable) {
   longclick_retriggerable = retriggerable;
+  has_longclick_retrigger_ms = false;
+  longclick_retrigger_ms = 0;
+}
+
+/////////////////////////////////////////////////////////////////
+
+void Button2::setLongClickDetectedRetriggerable(bool retriggerable, unsigned int retrigger_ms) {
+  longclick_retriggerable = retriggerable;
+  has_longclick_retrigger_ms = true;
+  longclick_retrigger_ms = retrigger_ms;
 }
 
 /////////////////////////////////////////////////////////////////
@@ -398,7 +408,11 @@ void Button2::_checkForLongClick(long now) {
   if (longclick_reported) return;
 
   // has the longclick_ms period has been exceeded?
-  if (now - down_ms < (longclick_time_ms * (longclick_counter + 1))) return;
+  unsigned int threshold_ms =
+    has_longclick_retrigger_ms
+      ? longclick_time_ms + longclick_retrigger_ms * longclick_counter
+      : (longclick_time_ms * (longclick_counter + 1));
+  if (now - down_ms < threshold_ms) return;
   // report multiple?
 
   if (!longclick_retriggerable) {

--- a/src/Button2.h
+++ b/src/Button2.h
@@ -61,12 +61,14 @@ class Button2 {
   unsigned long down_ms;
 
   bool longclick_retriggerable;
+  bool has_longclick_retrigger_ms = false;
   uint16_t longclick_counter = 0;
   bool longclick_detected = false;
   bool longclick_reported = false;
 
   unsigned int debounce_time_ms = BTN_DEBOUNCE_MS;
   unsigned int longclick_time_ms = BTN_LONGCLICK_MS;
+  unsigned int longclick_retrigger_ms = 0;
   unsigned int doubleclick_time_ms = BTN_DOUBLECLICK_MS;
 
   unsigned int down_time_ms = 0;
@@ -135,6 +137,7 @@ class Button2 {
   void setLongClickDetectedHandler(CallbackFunction f);
 
   void setLongClickDetectedRetriggerable(bool retriggerable);
+  void setLongClickDetectedRetriggerable(bool retriggerable, unsigned int retrigger_ms);
 
   unsigned int wasPressedFor() const;
   bool isPressed() const;


### PR DESCRIPTION
# Objective

I was trying to implement a standard interaction pattern with long press:

* User presses button
* Press action is executed immediately
* User continues pressing through long press delay (eg, 500ms)
* Long press action is executed
* Much shorter delay (eg, 100ms) is applied while button remains pressed
* Long press action is repeated at shorter interval while button is held

Classic example would be long-pressing to quickly navigate a long list of items.

I had attempted this with (simplified and slightly pseudocode):

```c++
btn.setPressedHandler(pressAction);
btn.setLongClickDetectedHandler(
    [this](Button2 &btn) {
        btn.setLongClickTime(100);
        pressAction(btn);
    }
);
btn.setLongClickHandler([this](Button2 &btn) {
    btn.setLongClickTime(500);
});
btn.setLongClickDetectedRetriggerable(true);
btn.setLongClickTime(500);
```

but this approach consistently caused the first 3-5 long click actions to execute with ~30ms delay. The exact timing is probably dependent on other factors, but the threshold was adjusted downward when `setLongClickTime(100)` was called, so these 3-5 initial repeats were effectively immediately executed while the timer caught up to the adjusted `longclick_counter` multiplier math.

The MR produces cleaner behavior with cleaner code:

```c++
btn.setPressedHandler(pressAction);
btn.setLongClickDetectedHandler(pressAction);
btn.setLongClickTime(500);
btn.setLongClickDetectedRetriggerable(true, 100);
```

# Considerations

I tried to come up with a clean way to avoid the `has_longclick_retrigger_ms` variable. Cleanest way would be to have an invalid value for `longclick_retrigger_ms`, ie `-1`, but uint to accommodate milliseconds precludes that option. Could default it to `longclick_time_ms`'s value at init and sync the two when they have the same value, but that felt like too much magic. Explicit flagging felt best.
