### PR TITLE
Fix Arduino Pico compilation error with PinMode enum (issue #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Note:** Unreleased changes are checked in but not part of an official release (available through the Arduino IDE or PlatfomIO) yet. This allows you to test WiP features and give feedback to them.
 
 ## Unreleased
+- **Fixed (Issue #88)**: Compilation error on Arduino Pico (RP2040) — `INPUT_PULLUP`, `OUTPUT`, and `INPUT` are defined as a `PinMode` enum on Pico, not as macros. The previous `#ifndef` guards only detect macros, so they failed to protect against redefining these constants, causing type mismatch errors with `PinMode`. Wrapped the fallback defines in `#ifndef ARDUINO` so they only apply in non-Arduino environments (e.g. native test builds)
 - **Updated**: Decoupled long-click retrigger interval from initial threshold 
 - **Fixed (CRITICAL)**: Type mismatch in internal timing methods — `_handlePress()`, `_handleRelease()`, `_pressedNow()`, `_releasedNow()`, and `_checkForLongClick()` now accept `unsigned long` instead of `long`, matching the return type of `millis()`. The previous `long` parameter caused incorrect timing arithmetic after ~24.8 days of uptime on AVR and ESP platforms
 - **Fixed**: `waitForClick()`, `waitForDouble()`, `waitForTriple()`, and `waitForLong()` were silently ignoring their `keepState` parameter — it is now correctly forwarded to `read()`

--- a/src/Button2.h
+++ b/src/Button2.h
@@ -26,21 +26,27 @@
 
 #include <Arduino.h>
 
-// Define Arduino constants if not available (for testing environments)
-#ifndef INPUT
-#define INPUT 0x0
-#endif
-#ifndef OUTPUT
-#define OUTPUT 0x1
-#endif
-#ifndef INPUT_PULLUP
-#define INPUT_PULLUP 0x2
-#endif
-#ifndef HIGH
-#define HIGH 0x1
-#endif
-#ifndef LOW
-#define LOW 0x0
+// Define Arduino constants if not available (for testing environments).
+// Wrapped in #ifndef ARDUINO to avoid overriding platform-native types (e.g.
+// Arduino Pico defines INPUT_PULLUP etc. as a PinMode enum, not a macro;
+// the plain #ifndef guards below cannot detect enum values, so without the
+// outer guard the macros would shadow the enum and cause type errors).
+#ifndef ARDUINO
+  #ifndef INPUT
+  #define INPUT 0x0
+  #endif
+  #ifndef OUTPUT
+  #define OUTPUT 0x1
+  #endif
+  #ifndef INPUT_PULLUP
+  #define INPUT_PULLUP 0x2
+  #endif
+  #ifndef HIGH
+  #define HIGH 0x1
+  #endif
+  #ifndef LOW
+  #define LOW 0x0
+  #endif
 #endif
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Wrap fallback INPUT/OUTPUT/INPUT_PULLUP/HIGH/LOW defines in #ifndef ARDUINO
so they are only applied in non-Arduino native environments. On Pico these
constants are a PinMode enum (not macros), so the previous #ifndef guards
silently redefined them as plain integers, causing type mismatch errors.
