### PR TITLE
fix: wasPressedFor() retains value after read() call (issue #96)

### DIFF
--- a/src/Button2.cpp
+++ b/src/Button2.cpp
@@ -244,7 +244,6 @@ void Button2::resetPressedState() {
   last_click_type = clickType::empty;
   last_click_count = 0;
   click_count = 0;
-  down_time_ms = 0;
   click_ms = 0;
   down_ms = 0;
   pressed_triggered = false;

--- a/test/test_states/test_states.cpp
+++ b/test/test_states/test_states.cpp
@@ -104,6 +104,27 @@ test(states, was_pressed_for_duration) {
 
 /////////////////////////////////////////////////////////////////
 
+test(states, was_pressed_for_after_read) {
+  Button2 button = createTestButton();
+  button.resetPressedState();
+
+  unsigned long pressDuration = 100;
+  click(button, pressDuration);
+  delay(BTN_DOUBLECLICK_MS);
+  button.loop();
+
+  // Consume the click via read(), which internally calls resetPressedState()
+  button.read();
+
+  // wasPressedFor() must still return the duration of the completed press
+  unsigned long measuredDuration = button.wasPressedFor();
+  assertTrue(measuredDuration > 0);
+  assertTrue(measuredDuration >= pressDuration - 20);
+  assertTrue(measuredDuration <= pressDuration + 100);
+}
+
+/////////////////////////////////////////////////////////////////
+
 test(states, get_number_of_clicks) {
   Button2 button = createTestButton();
   button.resetPressedState();


### PR DESCRIPTION
## Summary

- Removes `down_time_ms = 0` from `resetPressedState()` — it is a completed measurement, not active state, and must not be wiped when the click is consumed via `read()`
- Adds regression test `states_was_pressed_for_after_read` that calls `read()` before `wasPressedFor()` and asserts the duration is still correct

Fixes #96, reported by @mjculross.

## Root cause

`read()` internally calls `resetPressedState()`, which was zeroing `down_time_ms`. Since `_releasedNow()` sets that value on button release (before `read()` is ever called), the zero was discarding a valid measurement. All other fields reset in `resetPressedState()` represent in-progress state; `down_time_ms` alone is a historical result.

## Test plan

- [ ] `states_was_pressed_for_after_read` passes (new, would have failed before the fix)
- [ ] `states_was_pressed_for_duration` still passes (existing)
- [ ] All 69 tests green on epoxy-esp8266, epoxy-esp32, epoxy-nano