### PR TITLE
test: add read() contract tests and fix runner timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Unreleased
 - **Fixed (Issue #88)**: Compilation error on Arduino Pico (RP2040) — `INPUT_PULLUP`, `OUTPUT`, and `INPUT` are defined as a `PinMode` enum on Pico, not as macros. The previous `#ifndef` guards only detect macros, so they failed to protect against redefining these constants, causing type mismatch errors with `PinMode`. Wrapped the fallback defines in `#ifndef ARDUINO` so they only apply in non-Arduino environments (e.g. native test builds)
 - **Updated**: Decoupled long-click retrigger interval from initial threshold
+- **Fixed (Issue #96)**: `wasPressedFor()` always returned 0 when called after `read()`. `down_time_ms` is a completed measurement and must not be reset by `resetPressedState()`; removed the erroneous zero from that function
+- **Tests**: Added `read()` contract tests — verifying return value, state reset on `read()`, and state preservation on `read(true)`
 
 ## [2.6.0] - 2026-05-09
 

--- a/test/test_states/test_states.cpp
+++ b/test/test_states/test_states.cpp
@@ -22,6 +22,7 @@ using namespace aunit;
 
 void setup_test_runner() {
   TestRunner::setVerbosity(Verbosity::kDefault);
+  TestRunner::setTimeout(30);
   TestRunner::list();
 }
 
@@ -121,6 +122,58 @@ test(states, was_pressed_for_after_read) {
   assertTrue(measuredDuration > 0);
   assertTrue(measuredDuration >= pressDuration - 20);
   assertTrue(measuredDuration <= pressDuration + 100);
+}
+
+/////////////////////////////////////////////////////////////////
+
+test(states, read_returns_click_type) {
+  Button2 button = createTestButton();
+  button.resetPressedState();
+
+  click(button, DEBOUNCE_MS);
+  delay(BTN_DOUBLECLICK_MS);
+  button.loop();
+
+  assertEqual(button.read(), single_click);
+}
+
+/////////////////////////////////////////////////////////////////
+
+test(states, read_resets_state) {
+  Button2 button = createTestButton();
+  button.resetPressedState();
+
+  click(button, DEBOUNCE_MS);
+  delay(BTN_DOUBLECLICK_MS);
+  button.loop();
+
+  assertTrue(button.wasPressed());
+  assertEqual(button.getType(), single_click);
+  assertEqual(button.getNumberOfClicks(), (uint8_t)1);
+
+  button.read();
+
+  assertFalse(button.wasPressed());
+  assertEqual(button.getType(), clickType::empty);
+  assertEqual(button.getNumberOfClicks(), (uint8_t)0);
+}
+
+/////////////////////////////////////////////////////////////////
+
+test(states, read_keep_state_preserves_state) {
+  Button2 button = createTestButton();
+  button.resetPressedState();
+
+  click(button, DEBOUNCE_MS);
+  delay(BTN_DOUBLECLICK_MS);
+  button.loop();
+
+  clickType t = button.read(true);
+
+  assertEqual(t, single_click);
+  assertTrue(button.wasPressed());
+  assertEqual(button.getType(), single_click);
+  assertEqual(button.getNumberOfClicks(), (uint8_t)1);
 }
 
 /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

- Adds 3 tests for `read()` behavior that had no coverage: `read_returns_click_type`, `read_resets_state`, `read_keep_state_preserves_state`
- Bumps `TestRunner::setTimeout` from 10s to 30s — the additional tests pushed `test_states` past the default ceiling, causing `timing_very_fast_clicks` to time out
- Updates CHANGELOG with both the issue #96 fix (merged in #97) and these new tests

## Why these tests matter

The test suite had no cases verifying what `read()` actually does — it just happened to work. These tests lock in the contract so future regressions in `read()` (wrong return value, state not reset, `keepState` ignored) are caught immediately.

## Test plan

- [ ] `states_read_returns_click_type` passes
- [ ] `states_read_resets_state` passes
- [ ] `states_read_keep_state_preserves_state` passes
- [ ] `timing_very_fast_clicks` no longer times out
- [ ] All 23 `test_states` tests green on epoxy-esp8266, epoxy-esp32, epoxy-nano