### PR TITLE
chore: add Claude Code skills, hooks, and improve CLAUDE.md

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,48 @@
+{
+    "permissions": {
+      "allow": [
+        "Bash(pio test:*)",
+        "Bash(pio run:*)",
+        "Bash(gh issue view:*)",
+        "Bash(gh issue comment:*)",
+        "Bash(gh pr:*)",
+        "Bash(./test/compile_examples.sh:*)",
+        "Bash(git add:*)",
+        "Bash(git commit:*)",
+        "Bash(git checkout:*)",
+        "Bash(git push:*)",
+        "Bash(git tag:*)"
+      ],
+      "deny": [],
+      "ask": []
+    },
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Edit|Write",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "input=$(cat); echo \"$input\" | grep -q 
+  '\\.pio/' && echo 'Blocked: do not edit .pio/ build artifacts 
+  directly.' && exit 2 || exit 0"
+            }
+          ]
+        }
+      ],
+      "PostToolUse": [
+        {
+          "matcher": "Edit|Write",
+          "hooks": [
+            {
+              "type": "command",
+              "command": "input=$(cat); echo \"$input\" | grep -qE 
+  '\"file_path\".*/(src|test)/.*\\.(cpp|h)\"' && echo '--- Running 
+  tests ---' && pio test -e epoxy-esp8266 2>&1 | grep -E 
+  '(PASSED|FAILED|ERRORED)' || true"
+            }
+          ]
+        }
+      ]
+    }
+  }

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: commit
+description: Stage and commit current changes for Button2 — checks for needed CHANGELOG/README/CLAUDE.md updates, creates a branch if on master, writes a commit message, and commits
+---
+
+Commit the current working changes. Follow these steps:
+
+## Step 1: Understand what changed
+
+Run `git diff --stat` and `git status` to see what files are modified or untracked. Read the diffs for any changed source files (`src/`, `test/`, `examples/`) to understand the nature of the changes.
+
+## Step 2: Branch check
+
+Run `git branch --show-current`. If on `master` or `main`:
+- Infer a short branch name from the changes (e.g. `fix/was-pressed-for`, `feat/new-callback`, `docs/readme-update`)
+- Run `git checkout -b <branch-name>`
+- Tell the user which branch was created
+
+## Step 3: Check CHANGELOG
+
+If any source files (`src/`, `test/`, `examples/`) changed, check whether `CHANGELOG.md`'s `## Unreleased` section already documents those changes. If not, add the missing entries following the established format:
+- `**Fixed (Issue #N)**: ...` for bug fixes
+- `**Added**: ...` for new API or features  
+- `**Changed**: ...` for behavioral changes
+- `**Internal**: ...` for refactors, test additions, infra with no user-visible effect
+
+Skip changelog update for whitespace-only, comment, or docs-only changes.
+
+## Step 4: Check README
+
+If public API changed (new/removed/renamed functions in `src/Button2.h`), check whether `README.md` reflects the change. If not, update the relevant section. Skip for internal or test-only changes.
+
+## Step 5: Check CLAUDE.md
+
+If a non-obvious pattern, gotcha, or invariant was introduced that future sessions should know about, add a concise note to `CLAUDE.md`. Do not add obvious or one-off information.
+
+## Step 6: Stage and commit
+
+Stage all relevant files:
+```bash
+git add <changed source files> CHANGELOG.md  # plus README.md / CLAUDE.md if updated
+```
+
+Write a conventional commit message:
+- `fix:` for bug fixes
+- `feat:` for new features
+- `test:` for test-only changes
+- `docs:` for documentation only
+- `chore:` for tooling, config, infra
+
+Keep the subject line under 72 characters. Add a short body if the why isn't obvious from the subject.
+
+Run `git commit -m "..."` and confirm success.

--- a/.claude/skills/compile/SKILL.md
+++ b/.claude/skills/compile/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: compile
+description: Compile Button2 examples across Arduino platforms using arduino-cli and PlatformIO. Pass a platform name (esp8266, esp32, nano, all) or leave blank to compile all.
+---
+
+Compile Button2 examples to verify they build cleanly across target platforms.
+
+Parse $ARGUMENTS:
+- If a specific platform is named (esp8266, esp32, nano), run `pio run -e <matching env>` for that platform
+- If "examples" or nothing is given, run `./test/compile_examples.sh` to compile all examples across all platforms
+- If a specific example name is given, find the matching `.ino` file under `examples/` and compile it with `arduino-cli compile` for all three cores (esp8266:esp8266:d1_mini, esp32:esp32:m5stack_core2, arduino:avr:nano)
+
+Report any compiler errors clearly, quoting the relevant error lines. If compilation is clean, confirm which platforms and examples passed.

--- a/.claude/skills/readme/SKILL.md
+++ b/.claude/skills/readme/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: readme
+description: Audit README.md against the current Button2 API and recent CHANGELOG entries, then apply any needed updates
+---
+
+Audit and update `README.md` to reflect the current state of the library.
+
+## Step 1: Gather context
+
+- Read `src/Button2.h` — extract every public method signature and constant
+- Read the `## Unreleased` and most recent versioned section of `CHANGELOG.md`
+- Read `README.md` in full
+
+## Step 2: Identify gaps
+
+Compare the public API in `Button2.h` against what README documents. Flag:
+- Public methods present in the header but missing or outdated in README
+- Methods in README that no longer exist in the header
+- Default values or timing constants in README that differ from the header
+- New features mentioned in CHANGELOG that have no README coverage
+
+Do not flag internal helpers, private methods, or test infrastructure.
+
+## Step 3: Propose changes
+
+List each gap with a one-line description of what needs to change. If $ARGUMENTS contains "audit", stop here and show the list without editing.
+
+## Step 4: Apply updates
+
+For each gap, edit `README.md` in place:
+- Match the existing style, formatting, and section structure exactly
+- For new API entries, insert them in the same section and format as adjacent entries
+- For removed entries, delete them cleanly without leaving stubs or comments
+- Keep code examples consistent with the Arduino/ESP conventions in the file (no STL, no smart pointers)
+
+Report what was changed when done.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: release
+description: Cut a new Button2 release — suggests version bump based on change type, updates version files and CHANGELOG, commits, tags, and pushes
+---
+
+Cut a new Button2 release. Follow these steps exactly:
+
+## Step 1: Determine the version
+
+Read `library.json` to get the current version.
+
+Read the `## Unreleased` section of `CHANGELOG.md` to understand what changed.
+
+If $ARGUMENTS is provided, use that as the new version. Otherwise:
+- Classify the unreleased changes:
+  - **Major** (x.0.0): breaking API changes, removed functions, changed signatures
+  - **Minor** (x.y.0): new public functions, new features, new examples
+  - **Patch** (x.y.z): bug fixes, internal changes, test additions, docs
+- Suggest the new version with a one-line explanation of your reasoning
+- Use AskUserQuestion to ask the user to confirm the suggested version or provide a different one
+
+## Step 2: Update version files
+
+Update the version number in **both**:
+- `library.json` — the `"version"` field
+- `library.properties` — the `version=` line
+
+## Step 3: Finalize CHANGELOG
+
+In `CHANGELOG.md`:
+- Rename `## Unreleased` to `## [x.y.z] - YYYY-MM-DD` (use today's date and the new version)
+- Add a fresh `## Unreleased` section above it (empty, just the heading)
+
+ ## Step 4: Commit, tag, push
+  
+  Run these commands in order:
+  ```bash
+  git add library.json library.properties CHANGELOG.md
+  git commit -m "chore: release vX.Y.Z"
+  git tag vX.Y.Z
+  git push && git push --tags
+
+  Step 5: Publish to PlatformIO registry
+
+  pio pkg publish --no-interactive
+
+  This pushes directly to the PlatformIO registry. The Arduino Library Manager picks up the new tag automatically from GitHub — no separate step
+  needed there.
+
+  Confirm each step succeeded and report which registries were updated.

--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: test
+description: Run Button2 test suites via PlatformIO. Optionally pass a suite name (basics, clicks, callbacks, states, configuration, multiple) or platform (esp8266, esp32, nano). Defaults to all suites on ESP8266.
+---
+
+Run the Button2 test suite using PlatformIO + EpoxyDuino (no hardware required).
+
+Parse $ARGUMENTS:
+- If a specific suite is named (basics, clicks, callbacks, states, configuration, multiple), run `pio test -e test_<suite>`
+- If a platform is named (esp8266, esp32, nano), run `pio test -e epoxy-<platform>`
+- If "all" or nothing is given, run `pio test -e epoxy-esp8266 -e epoxy-esp32 -e epoxy-nano`
+
+Show the filtered output (`grep -E '(PASSED|FAILED|ERRORED|summary)'`) and report how many suites passed vs failed.
+
+If any suite fails, show the full verbose output for the failing suite so the failure is easy to diagnose.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Fixed (Issue #88)**: Compilation error on Arduino Pico (RP2040) — `INPUT_PULLUP`, `OUTPUT`, and `INPUT` are defined as a `PinMode` enum on Pico, not as macros. The previous `#ifndef` guards only detect macros, so they failed to protect against redefining these constants, causing type mismatch errors with `PinMode`. Wrapped the fallback defines in `#ifndef ARDUINO` so they only apply in non-Arduino environments (e.g. native test builds)
 - **Updated**: Decoupled long-click retrigger interval from initial threshold
 - **Fixed (Issue #96)**: `wasPressedFor()` always returned 0 when called after `read()`. `down_time_ms` is a completed measurement and must not be reset by `resetPressedState()`; removed the erroneous zero from that function
+- **Internal**: Added Claude Code project skills (`/commit`, `/release`, `/test`, `/compile`, `/readme`), auto-test and `.pio/` guard hooks, and updated CLAUDE.md with `read()` contract, runner timeout note, and changelog/README rules
 - **Tests**: Added `read()` contract tests — verifying return value, state reset on `read()`, and state preservation on `read(true)`
 
 ## [2.6.0] - 2026-05-09

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,24 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Button2 is an Arduino/ESP library for handling physical buttons with advanced click detection, debouncing, and callback support. Targets Arduino Uno/Nano (AVR), ESP8266, and ESP32.
 
+## Changelog Rule
+
+**Always update `CHANGELOG.md` when making code changes.** After every bug fix, feature addition, or behavioral change, add a bullet to the `## Unreleased` section before committing. Use the format already established in the file:
+
+- `**Fixed (Issue #N)**: ...` for bug fixes
+- `**Added**: ...` for new public API or features
+- `**Changed**: ...` for behavioral changes
+- `**Internal**: ...` for refactors, test additions, infra changes with no user-visible effect
+
+Do not add changelog entries for typo fixes, comment edits, or whitespace-only changes.
+
+Also update `README.md` when:
+- A new public function is added or an existing one is removed/renamed → update the API Reference section
+- Default timing values or behavior change → update the relevant description
+- A new usage pattern or example is introduced → add or update the relevant section
+
+Do not update README for internal refactors, test changes, or bug fixes that don't affect observable behavior.
+
 ## Development Commands
 
 ```bash
@@ -28,6 +46,9 @@ pio test -e test_multiple
 # Build / upload
 pio run -e Wemos_D1_Mini
 pio run -t upload -e Wemos_D1_Mini
+
+# Publish to PlatformIO registry (run after tagging a release)
+pio pkg publish --no-interactive
 ```
 
 Prerequisites: `arduino-cli`, PlatformIO, and cores `esp8266:esp8266 esp32:esp32 arduino:avr`.
@@ -84,6 +105,14 @@ button.begin(BTN_VIRTUAL_PIN, INPUT_PULLUP, true);     // 3. begin() reads state
 ```
 
 All six test suites share helpers via `test/shared/test_helpers.h` (`createTestButton()`, `click()`, `press()`, `release()`). Add new tests there, not inline in a single suite.
+
+## read() / resetPressedState() Contract
+
+`read()` calls `resetPressedState()` internally. After `read()`:
+- `wasPressedFor()` — **survives** (`down_time_ms` is a completed measurement, not active state)
+- `wasPressed()`, `getType()`, `getNumberOfClicks()` — **reset to defaults** (by design)
+
+Do not add `down_time_ms = 0` back to `resetPressedState()` — this was the bug in issue #96.
 
 ## Architecture
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -4,14 +4,14 @@ This file provides specific guidance for AI assistants (especially Claude Code) 
 
 ## Test Suite Overview
 
-The Button2 test suite consists of **68 comprehensive tests** organized into 6 test suites:
+The Button2 test suite consists of **72 comprehensive tests** organized into 6 test suites:
 
-1. **test_basics** (6 tests) - Button initialization, configuration, and fundamental operations
+1. **test_basics** (10 tests) - Button initialization, configuration, and fundamental operations
 2. **test_clicks** (12 tests) - Click detection (single, double, triple, long, patterns)
-3. **test_callbacks** (12 tests) - All event handler callbacks
-4. **test_states** (19 tests) - State management, queries, and timing edge cases
+3. **test_callbacks** (13 tests) - All event handler callbacks
+4. **test_states** (23 tests) - State management, queries, timing edge cases, read() contract
 5. **test_configuration** (7 tests) - Settings management and property validation
-6. **test_multiple** (12 tests) - Multiple button scenarios and interactions
+6. **test_multiple** (11 tests) - Multiple button scenarios and interactions
 
 ## Testing Architecture
 
@@ -43,22 +43,6 @@ Button2 createTestButton() {
 
   return button;
 }
-```
-
-### Why This Order Matters
-
-❌ **WRONG** - Will cause phantom clicks and state issues:
-```cpp
-button.begin(PIN, MODE, true);              // Reads undefined state
-button.setButtonStateFunction(func);        // Too late!
-simulatedPinState = HIGH;                   // Way too late!
-```
-
-✅ **CORRECT** - Proper initialization:
-```cpp
-simulatedPinState = HIGH;                   // 1. Set state first
-button.setButtonStateFunction(func);        // 2. Inject reader
-button.begin(PIN, MODE, true);              // 3. Now reads correct state
 ```
 
 ## Critical Testing Rules
@@ -152,137 +136,6 @@ test(callbacks, click_handler) {
   button.loop();               // Process the timeout
 
   assertTrue(g_clicked);
-}
-```
-
-## Test Suite Patterns
-
-### test_basics/
-
-Basic functionality and initialization tests:
-
-```cpp
-test(basics, equal_operator) {
-  Button2 button1 = createTestButton();
-  Button2 button2 = createTestButton();
-
-  assertTrue(button1 == button1);
-  assertFalse(button1 == button2);
-}
-```
-
-### test_clicks/
-
-Click detection tests:
-
-```cpp
-test(clicks, double_click) {
-  Button2 button = createTestButton();
-  button.resetPressedState();
-
-  // Two quick clicks
-  click(button, DEBOUNCE_MS);
-  click(button, DEBOUNCE_MS);
-
-  // Wait for double-click to be reported
-  delay(BTN_DOUBLECLICK_MS);
-  button.loop();
-
-  assertEqual(button.getType(), double_click);
-  assertEqual(button.getNumberOfClicks(), 2);
-}
-```
-
-### test_callbacks/
-
-Callback handler tests:
-
-```cpp
-test(callbacks, long_click_detected_handler) {
-  resetHandlerVars();
-  Button2 button = createTestButton();
-  button.resetPressedState();
-
-  button.setLongClickDetectedHandler([](Button2& b) {
-    g_long_detected = true;
-  });
-
-  // Press and hold past threshold
-  simulatedPinState = BUTTON_ACTIVE;
-  button.loop();
-
-  unsigned long startTime = millis();
-  while (millis() - startTime < (BTN_LONGCLICK_MS + 100)) {
-    button.loop();
-    delay(1);
-  }
-
-  // Handler called WHILE still pressed
-  assertTrue(g_long_detected);
-
-  // Release
-  simulatedPinState = !BUTTON_ACTIVE;
-  button.loop();
-}
-```
-
-### test_states/
-
-State management and timing tests:
-
-```cpp
-test(states, is_pressed_raw) {
-  Button2 button = createTestButton();
-
-  // isPressedRaw reflects immediate pin state
-  simulatedPinState = BUTTON_ACTIVE;
-  assertTrue(button.isPressedRaw());
-
-  simulatedPinState = !BUTTON_ACTIVE;
-  assertFalse(button.isPressedRaw());
-}
-```
-
-### test_configuration/
-
-Configuration management tests:
-
-```cpp
-test(settings, longclick_time) {
-  Button2 button = createTestButton();
-
-  button.setLongClickTime(BTN_LONGCLICK_MS + 1);
-  assertEqual(button.getLongClickTime(), (unsigned int)(BTN_LONGCLICK_MS + 1));
-}
-```
-
-### test_multiple/
-
-Multiple button interaction tests:
-
-```cpp
-test(multiple, shared_handler_different_buttons) {
-  resetTestState();
-
-  Button2 button1 = createTestButton(PIN1, func1, &state1);
-  Button2 button2 = createTestButton(PIN2, func2, &state2);
-
-  button1.setID(1);
-  button2.setID(2);
-
-  // Shared handler tracks which button was clicked
-  auto sharedHandler = [](Button2& b) {
-    g_last_button_id = b.getID();
-  };
-
-  button1.setClickHandler(sharedHandler);
-  button2.setClickHandler(sharedHandler);
-
-  click(button1, &state1, DEBOUNCE_MS);
-  delay(BTN_DOUBLECLICK_MS);
-  button1.loop();
-
-  assertEqual(g_last_button_id, 1);
 }
 ```
 
@@ -405,15 +258,19 @@ pio test -e epoxy-esp8266 -e epoxy-esp32 -e epoxy-nano -v
 
 ### Expected Results
 
-All 68 tests should pass:
-- ✅ test_basics: 6 passed
+All 72 tests should pass:
+- ✅ test_basics: 10 passed
 - ✅ test_clicks: 12 passed
-- ✅ test_callbacks: 12 passed
-- ✅ test_states: 19 passed
+- ✅ test_callbacks: 13 passed
+- ✅ test_states: 23 passed
 - ✅ test_configuration: 7 passed
-- ✅ test_multiple: 12 passed
+- ✅ test_multiple: 11 passed
 
-Total execution time: ~34 seconds on epoxy-esp8266
+Total execution time: ~35 seconds on epoxy-esp8266
+
+### Runner Timeout
+
+`test_states` sets `TestRunner::setTimeout(30)` in `setup_test_runner()` — the default 10s was too short once the suite grew past ~20 tests. If you add tests to a suite that starts timing out, increase its timeout the same way.
 
 ## Adding New Tests
 
@@ -506,15 +363,3 @@ Tests are platform-agnostic:
 - ✅ No platform-specific features in core tests
 - ✅ Platform differences handled in library, not tests
 
-## Summary
-
-**Remember the golden rules:**
-
-1. ✅ Set `simulatedPinState` BEFORE `begin()`
-2. ✅ Call `button.loop()` repeatedly while button is pressed
-3. ✅ Wait for timeouts and call `loop()` before checking results
-4. ✅ Reset all state with `resetHandlerVars()` at start of each test
-5. ✅ Use local button instances, never global
-6. ✅ Cast literals to `(unsigned int)` for assertEqual() with timing values
-
-Follow these patterns and your tests will be robust, reliable, and maintainable!


### PR DESCRIPTION
## Summary

- Adds 5 project skills: `/commit`, `/release`, `/test`, `/compile`, `/readme`
- Adds `.claude/settings.json` with project permissions and two hooks:
  - **PostToolUse**: auto-runs `pio test -e epoxy-esp8266` after any edit to `src/` or `test/` files
  - **PreToolUse**: blocks edits to `.pio/` build artifacts
- Updates `CLAUDE.md`: moved Overview to top, added `read()`/`resetPressedState()` contract, `pio pkg publish` command, and changelog/README update rules
- Trims `test/CLAUDE.md`: removes ~180 lines of redundant per-suite examples and duplicate init-order block; updates test counts to 72; documents runner timeout

## Notes

- `settings.local.json` renamed to `settings.json` so hooks and permissions are shared (committed)
- Skills are in `.claude/skills/` and checked into git as project-level workflow docs